### PR TITLE
Temp unit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ wego is a weather client for the terminal.
 6. If you're visiting someone in e.g. London over the weekend, just run
    `wego 4 London` or `wego London 4` (the ordering of arguments makes no
    difference) to get the forecast for the current and the next 3 days.
-
+7. OPTIONAL - By default the temperature is displayed in Celsius. To display in Fahrenheit,
+   add the `"Unit" : "F"` to your `.wegorc`.
+   
 ##License
 
 Copyright (c) 2015,  <teichm@in.tum.de>

--- a/we.go
+++ b/we.go
@@ -18,6 +18,7 @@ import (
 type configuration struct {
 	APIKey string
 	City   string
+	TempUnit   string
 }
 
 type cond struct {
@@ -272,6 +273,14 @@ func configsave() error {
 	return err
 }
 
+func getTempUnit() string{
+     if(config.TempUnit == "F" || config.TempUnit == "f"){
+            return "F"
+     } else {
+       	    return "C"
+     }
+}
+
 func formatTemp(c cond) string {
 	color := func(temp int) string {
 		var col = 21
@@ -300,14 +309,18 @@ func formatTemp(c cond) string {
 				col = 196
 			}
 		}
-		return fmt.Sprintf("\033[38;5;%03dm%d\033[0m", col, temp)
+		temp_unit:= float32(temp)
+		if(getTempUnit() == "F"){
+		       temp_unit = float32(temp) * 1.8 + 32.0
+		} 
+		return fmt.Sprintf("\033[38;5;%03dm%d\033[0m", col, int32(temp_unit))
 	}
 	if c.FeelsLikeC < c.TempC {
-		return fmt.Sprintf("%s – %s °C         ", color(c.FeelsLikeC), color(c.TempC))[:48]
+		return fmt.Sprintf("%s – %s °%s         ", color(c.FeelsLikeC), color(c.TempC), getTempUnit())[:48]
 	} else if c.FeelsLikeC > c.TempC {
-		return fmt.Sprintf("%s – %s °C         ", color(c.TempC), color(c.FeelsLikeC))[:48]
+		return fmt.Sprintf("%s – %s °%s         ", color(c.TempC), color(c.FeelsLikeC), getTempUnit())[:48]
 	} else {
-		return fmt.Sprintf("%s °C            ", color(c.FeelsLikeC))[:31]
+		return fmt.Sprintf("%s °%s            ", color(c.FeelsLikeC), getTempUnit())[:31]
 	}
 }
 


### PR DESCRIPTION
Added an optional temperature unit config parameter, so the temperatures can be displayed in Fahrenheit. If the parameter `tempUnit` isn't set in the .wegorc, the app will default to Celsius. 