### PR TITLE
Allow zip codes and num of days for use

### DIFF
--- a/we.go
+++ b/we.go
@@ -484,7 +484,7 @@ func main() {
 	params = append(params, "key="+config.APIKey)
 
 	for _, arg := range os.Args[1:] {
-		if v, err := strconv.Atoi(arg); err == nil {
+		if v, err := strconv.Atoi(arg); err == nil && len(arg) == 1 {
 			numdays = v
 		} else {
 			config.City = arg


### PR DESCRIPTION
Allow using zipcodes without breaking api compatibility. num_of_days will still get set if number is less than 5. Very useful because of ambiguous city names (Dallas, TX and Dallas, GA).

Example:
``` 
wego 12345 5
wego 5 12345
wego Dallas 3
wego 3 Dallas
```