### PR TITLE
Add verbose info message when launching without .wegorc

### DIFF
--- a/we.go
+++ b/we.go
@@ -489,6 +489,7 @@ func init() {
 	config.Imperial = false
 	err = configload()
 	if _, ok := err.(*os.PathError); ok {
+		log.Printf("No config file found. Creating %s ...", configpath)
 		if err := configsave(); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Right now it is a bit confusing when you just launch wego without reading the README first :-)