### PR TITLE
Don't Use Floats For Metric Conversions

### DIFF
--- a/we.go
+++ b/we.go
@@ -345,11 +345,10 @@ func formatTemp(c cond) string {
 				col = 196
 			}
 		}
-		tempUnit := float32(temp)
 		if config.Imperial {
-			tempUnit = float32(temp)*1.8 + 32.0
+			temp = (temp * 18 + 320) / 10
 		}
-		return fmt.Sprintf("\033[38;5;%03dm%d\033[0m", col, int32(tempUnit))
+		return fmt.Sprintf("\033[38;5;%03dm%d\033[0m", col, temp)
 	}
 	t := c.TempC
 	if t == 0 {


### PR DESCRIPTION
One should never use floats for metric conversions. Integers are always faster than Floats and should therefore never be used when converting one known unit system to another known unit system. Floats are only to be used when calculating units of unknown scale that are highly sensitive to measurements.

In this case, the formula for finding the temperature in F using integer math is (C * 18 + 320) / 10. If C(32) * 1.8 + 32 = 89.6, then C(32) * 18 + 320 = 896. 896 / 10 therefore becomes 89. If we know that we are going to calculate math with a single decimal point, then shifting our math upwards by one magnitude will keep our math the same. It is similar to how $0.01 USD is equal to 1 cent, and therefore $3.50 is equal to 350 cents. Accounting software (USD) performs math with a metric of cents and formats the integer with a period when being displayed to the user.

This also removes the additional allocation of an unnecessary variable (tempUnit) as the (temp) variable will automatically be destroyed at the end of the function call anyway.