### PR TITLE
fix east asian ambiguous runes

### DIFF
--- a/we.go
+++ b/we.go
@@ -421,8 +421,13 @@ func formatWind(c cond) string {
 		return fmt.Sprintf("\033[38;5;%03dm%d\033[0m", col, spd)
 	}
 	if c.WindGustKmph > c.WindspeedKmph {
-		return pad(fmt.Sprintf("%s %s – %s %s", windDir[c.Winddir16Point], color(c.WindspeedKmph), color(c.WindGustKmph), unitWind[config.Imperial]), 15)
+		if(runewidth.StringWidth("─") == 2){
+			return pad(fmt.Sprintf("%s%s – %s%s", windDir[c.Winddir16Point], color(c.WindspeedKmph), color(c.WindGustKmph), unitWind[config.Imperial]), 14)
+		}else{
+			return pad(fmt.Sprintf("%s %s – %s %s", windDir[c.Winddir16Point], color(c.WindspeedKmph), color(c.WindGustKmph), unitWind[config.Imperial]), 15)
+		}
 	}
+	
 	return pad(fmt.Sprintf("%s %s %s", windDir[c.Winddir16Point], color(c.WindspeedKmph), unitWind[config.Imperial]), 15)
 }
 
@@ -680,6 +685,14 @@ func main() {
 	}
 	for _, d := range r.Data.Weather {
 		for _, val := range printDay(d) {
+			if(runewidth.StringWidth("─") == 2){
+				rep := strings.NewReplacer("─", "-", "│", "|", "┼", "+",
+					"┬", "+", "┴", "+", "┤", "+", "┌", "+", "┐", "+",
+					"└", "+", "┘", "+", "├", "+", "°C", "℃",
+					"‘", "`", "’", "'", "–", "-", "―", "-",
+				)
+				val = rep.Replace(val)
+			}
 			fmt.Fprintln(stdout, val)
 		}
 	}


### PR DESCRIPTION
BOX DRAWINGS(─) and ARROW(↑￼→￼↓￼←) are East Asian Ambiguous charactors.
http://unicode.org/reports/tr11/
So they break ascii art depends on terminal or locale.
We need to option that allow to switch half width and full width for EAW charactors.
This is my first aid patch:
Thank you.

Original:
![orig](https://cloud.githubusercontent.com/assets/12780/13212122/f9e6de58-d981-11e5-9327-f56a2e6b6b84.png)

Fixed:
![fix](https://cloud.githubusercontent.com/assets/12780/13212123/fc71deb6-d981-11e5-8dce-bc4a7e0f58bd.png)
