### PR TITLE
Differentiate clear weather at night vs day

### DIFF
--- a/backends/forecast.io.go
+++ b/backends/forecast.io.go
@@ -90,7 +90,7 @@ func (c *forecastConfig) ParseDaily(db forecastDataBlock, numdays int) []iface.D
 func (c *forecastConfig) parseCond(dp forecastDataPoint) (ret iface.Cond, err error) {
 	codemap := map[string]iface.WeatherCode{
 		"clear-day":           iface.CodeSunny,
-		"clear-night":         iface.CodeSunny,
+		"clear-night":         iface.CodeClearNight,
 		"rain":                iface.CodeLightRain,
 		"snow":                iface.CodeLightSnow,
 		"sleet":               iface.CodeLightSleet,

--- a/frontends/ascii-art-table.go
+++ b/frontends/ascii-art-table.go
@@ -257,6 +257,13 @@ func (c *aatConfig) formatCond(cur []string, cond iface.Cond, current bool) (ret
 			"\033[38;5;226m     `-᾿     \033[0m",
 			"\033[38;5;226m    /   \\    \033[0m",
 		},
+		iface.CodeClearNight: {
+			"\033[38;5;255m  *   .--,   \033[0m",
+			"\033[38;5;255m    /   /    \033[0m",
+			"\033[38;5;255m   |   |     \033[0m",
+			"\033[38;5;255m    \\   \\  * \033[0m",
+			"\033[38;5;255m *    `--`   \033[0m",
+		},
 		iface.CodeThunderyHeavyRain: {
 			"\033[38;5;240;1m     .-.     \033[0m",
 			"\033[38;5;240;1m    (   ).   \033[0m",

--- a/frontends/emoji.go
+++ b/frontends/emoji.go
@@ -73,6 +73,7 @@ func (c *emojiConfig) formatCond(cur []string, cond iface.Cond, current bool) (r
 		iface.CodeLightSnowShowers:    {"🌨"},
 		iface.CodePartlyCloudy:        {"⛅️"},
 		iface.CodeSunny:               {"☀️"},
+		iface.CodeClearNight:          {"🌜"},
 		iface.CodeThunderyHeavyRain:   {"🌩"},
 		iface.CodeThunderyShowers:     {"⛈"},
 		iface.CodeThunderySnowShowers: {"⛈"},

--- a/iface/iface.go
+++ b/iface/iface.go
@@ -23,6 +23,7 @@ const (
 	CodeLightSnowShowers
 	CodePartlyCloudy
 	CodeSunny
+	CodeClearNight
 	CodeThunderyHeavyRain
 	CodeThunderyShowers
 	CodeThunderySnowShowers


### PR DESCRIPTION
I've had a go at fixing #68 (night should be moon instead of a sun).

This includes an ascii moon/stars for the `ascii-art-table` frontend and an appropriate character in place for the emoji frontend.

Only fixed for the forecast.io as the placeholders were already there, and I don't have access to any API keys for wwo.

Here's how it looks for a suitably sunny/clear location:
<img width="887" alt="screen shot 2016-04-26 at 23 03 37" src="https://cloud.githubusercontent.com/assets/1330154/14835734/46243384-0c03-11e6-911a-6eb21b16ae75.png">
