### PR TITLE
Moved forecast.io to darksky.net

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,8 +48,8 @@ func main() {
 	flag.IntVar(numdays, "d", 3, "`NUMBER` of days of weather forecast to be displayed (shorthand)")
 	unitSystem := flag.String("units", "metric", "`UNITSYSTEM` to use for output.\n    \tChoices are: metric, imperial, si, metric-ms")
 	flag.StringVar(unitSystem, "u", "metric", "`UNITSYSTEM` to use for output. (shorthand)\n    \tChoices are: metric, imperial, si, metric-ms")
-	selectedBackend := flag.String("backend", "forecast.io", "`BACKEND` to be used")
-	flag.StringVar(selectedBackend, "b", "forecast.io", "`BACKEND` to be used (shorthand)")
+	selectedBackend := flag.String("backend", "darksky", "`BACKEND` to be used")
+	flag.StringVar(selectedBackend, "b", "darksky", "`BACKEND` to be used (shorthand)")
 	selectedFrontend := flag.String("frontend", "ascii-art-table", "`FRONTEND` to be used")
 	flag.StringVar(selectedFrontend, "f", "ascii-art-table", "`FRONTEND` to be used (shorthand)")
 


### PR DESCRIPTION
Here's my attempt to fix #97. 

Fully tested and functional on my machine. If an old config (i.e. one utilizing forecast.io) is used, the user is provided a warning and the application closes gracefully.

I personally don't think any other special handling is needed, as mentioned and postponed on in #98. Doing so would require extra modifications to the functionality of https://github.com/schachmat/ingo to allow flag migration.