### PR TITLE
Corrected temperatures in openweathermap.org backend

### DIFF
--- a/backends/openweathermap.org.go
+++ b/backends/openweathermap.org.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/schachmat/wego/iface"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/schachmat/wego/iface"
 )
 
 type openWeatherConfig struct {
@@ -31,9 +32,9 @@ type openWeatherResponse struct {
 type dataBlock struct {
 	Dt   int64 `json:"dt"`
 	Main struct {
-		TempMin  float32 `json:"temp_min"`
-		TempMax  float32 `json:"temp_max"`
-		Humidity int     `json:"humidity"`
+		TempC      float32 `json:"temp"`
+		FeelsLikeC float32 `json:"feels_like"`
+		Humidity   int     `json:"humidity"`
 	} `json:"main"`
 
 	Weather []struct {
@@ -201,8 +202,8 @@ func (c *openWeatherConfig) parseCond(dataInfo dataBlock) (iface.Cond, error) {
 	ret.Code = iface.CodeUnknown
 	ret.Desc = dataInfo.Weather[0].Description
 	ret.Humidity = &(dataInfo.Main.Humidity)
-	ret.TempC = &(dataInfo.Main.TempMin)
-	ret.FeelsLikeC = &(dataInfo.Main.TempMax)
+	ret.TempC = &(dataInfo.Main.TempC)
+	ret.FeelsLikeC = &(dataInfo.Main.FeelsLikeC)
 	if &dataInfo.Wind.Deg != nil {
 		p := int(dataInfo.Wind.Deg)
 		ret.WinddirDegree = &p


### PR DESCRIPTION
Openweathermap.org backend sent min(max) temperatures to frontend instead of measured(felt), as other backends do, so I replaced `json:"temp_min"` and  `json:"temp_max"` with `json:"temp"` and `json:"feels_like"`.