### PR TITLE
Update versions for github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20
+        go-version-file: './go.mod'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
The builds can be fixed by updating the versions of actions being used. I saw that `main` is currently failing.