### PR TITLE
Remove º from Kelvin temperature

### DIFF
--- a/iface/iface.go
+++ b/iface/iface.go
@@ -123,7 +123,7 @@ func (u UnitSystem) Temp(tempC float32) (res float32, unit string) {
 	} else if u == UnitsImperial {
 		return tempC*1.8 + 32, "°F"
 	} else if u == UnitsSi {
-		return tempC + 273.16, "°K"
+		return tempC + 273.16, "K"
 	}
 	log.Fatalln("Unknown unit system:", u)
 	return


### PR DESCRIPTION
Bug fix for issue #170

### Motivation and Context
The change is to correct a bug reported on issue #170

### Description
Removed º symbol from Temp function on iface

### Steps for Testing
Use --units si to set metric system

### Screenshots
![image](https://github.com/user-attachments/assets/2cfe97c2-fbfc-4069-aff0-08470b20ebdd)
