### PR TITLE
Openmeteo correction for daily astronomy.

### DIFF
--- a/backends/open-meteo.com.go
+++ b/backends/open-meteo.com.go
@@ -213,12 +213,13 @@ func (opmeteo *openmeteoConfig) Fetch(location string, numdays int) iface.Data {
 
 	forecast := opmeteo.parseDaily(resp.Hourly)
 
+	for i, _ := range forecast {
+		forecast[i].Astronomy.Sunset = time.Unix(resp.Daily.Sunset[i], 0)
+		forecast[i].Astronomy.Sunrise = time.Unix(resp.Daily.Sunrise[i], 0)
+	}
 	if len(forecast) > 0 {
-		forecast[0].Astronomy.Sunset = time.Unix(resp.Daily.Sunset[0], 0)
-		forecast[0].Astronomy.Sunrise = time.Unix(resp.Daily.Sunrise[0], 0)
 		ret.Forecast = forecast
 	}
-
 	return ret
 }
 


### PR DESCRIPTION
Current openweather api usage does not have daily astronomy. Api "onecall" seems to have.
Openmeteo has daily astronomy

### Motivation and Context
When requesting the output as json, daily astronomy data was not set correctly (only one day)

### Description
Since Openmeteo has daily astronomy I have corrected the forecast data for each day.

### Steps for Testing
Execute with frontend flag set for json ( -f json ). Each day should have sunrise and sunset correctly set.

### Screenshots
![image](https://github.com/user-attachments/assets/927e688a-38f9-4efb-9ea5-ec443e7649ab)
![image](https://github.com/user-attachments/assets/74e49779-53f6-4fd6-aa93-7c7defd081a1)
