### PR TITLE
Query openweathermap API over https

### DIFF
--- a/backends/openweathermap.org.go
+++ b/backends/openweathermap.org.go
@@ -56,7 +56,7 @@ type dataBlock struct {
 }
 
 const (
-	openweatherURI = "http://api.openweathermap.org/data/2.5/forecast?%s&appid=%s&units=metric&lang=%s"
+	openweatherURI = "https://api.openweathermap.org/data/2.5/forecast?%s&appid=%s&units=metric&lang=%s"
 )
 
 func (c *openWeatherConfig) Setup() {


### PR DESCRIPTION
> Features:
> - ssl, so the NSA has a harder time learning where you live or plan to go

And yet openweathermap is queried over plain http.